### PR TITLE
Optionally pass line-height to font-size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+- allow setting `line-height` in `font-size` mixin
+
 ## 1.0.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 1.1.0
 
 ### Added
 - allow setting `line-height` in `font-size` mixin

--- a/dist/_type.scss
+++ b/dist/_type.scss
@@ -177,25 +177,30 @@
 /// Apply responsive text sizing to an element.
 /// Use only whole numbers to maintain proper typographic scale.
 /// @param {number} $n - negative or positive number (0 is default size)
+/// @param {number} $line-height - line-height you'd like to use (default chosen based on size)
 /// @example scss
 ///   @include font-size(-1); // one step smaller on the scale
-///   @include font-size(2); // two steps larger on the scale
-@mixin font-size($n) {
+///   @include font-size(2, 1.25); // two steps larger on the scale, 1.25 line-height
+@mixin font-size($n, $line-height: null) {
   font-size: modular-scale($n, $ratio);
-  @if $n > 7 {
-    line-height: $baseline-ratio*.85;
-  }
-  @else if $n <= 7 and $n > 5 {
-    line-height: $baseline-ratio*.875;
-  }
-  @else if $n <= 5 and $n > 3 {
-    line-height: $baseline-ratio*.9;
-  }
-  @else if $n <= 3 and $n > 2 {
-    line-height: $baseline-ratio*.925;
-  }
-  @else if $n <= 2 {
-    line-height: $baseline-ratio;
+  @if $line-height {
+    line-height: $line-height;
+  } @else {
+    @if $n > 7 {
+      line-height: $baseline-ratio*.85;
+    }
+    @else if $n <= 7 and $n > 5 {
+      line-height: $baseline-ratio*.875;
+    }
+    @else if $n <= 5 and $n > 3 {
+      line-height: $baseline-ratio*.9;
+    }
+    @else if $n <= 3 and $n > 2 {
+      line-height: $baseline-ratio*.925;
+    }
+    @else if $n <= 2 {
+      line-height: $baseline-ratio;
+    }
   }
   @if $n > 0 {
     @media screen and (max-width: $viewport-medium - 1) {

--- a/docs/index.html
+++ b/docs/index.html
@@ -1152,7 +1152,7 @@
                 <section id="Type-font-size" class="trailer-2">
                     <h3 class="font-size-2 avenir-bold">
                         font-size
-                        ($n)
+                        ($n, $line-height)
                     </h3>
                     <p>Apply responsive text sizing to an element.
 Use only whole numbers to maintain proper typographic scale.
@@ -1183,6 +1183,19 @@ Use only whole numbers to maintain proper typographic scale.
                                 </td>
                                 </tr>
                             
+                                <tr class="item__parameter">
+                                    <th><code>$line-height</code></th>
+                                    <td>line-height you'd like to use (default chosen based on size)</td>
+                                    <td data-label="type">
+                                        <span class="label">number</span>
+                                    </td>
+                                    <td>
+                                    
+                                        &mdash;<span class="visually-hidden"> none</span>
+                                    
+                                </td>
+                                </tr>
+                            
                             </tbody>
                         </table>
                     
@@ -1193,7 +1206,7 @@ Use only whole numbers to maintain proper typographic scale.
 
                         
                         <pre class="language-scss"><code>@include font-size(-1); // one step smaller on the scale
-@include font-size(2); // two steps larger on the scale</code></pre>
+@include font-size(2, 1.25); // two steps larger on the scale, 1.25 line-height</code></pre>
 
                     
                     

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@esri/calcite-base",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Tokens, mixins, and other Sass utilities for Esri's Calcite Design System",
   "homepage": "https://github.com/Esri/calcite-base",
   "main": "dist/index.js",


### PR DESCRIPTION
Pretty commonly we're overriding the default line-height generated by font-size. This allows devs to set the line-height explicitly with an optional parameter.