### PR TITLE
Adds transparency helper function to utils

### DIFF
--- a/dist/_utils.scss
+++ b/dist/_utils.scss
@@ -66,3 +66,12 @@
     width: auto;
   }
 }
+
+/// Add transparency to a requested color
+/// @param {string} $color - Pass a color value
+/// @param {number} $level - Pass an alpha level as number
+
+@function transparency($color, $level) {
+  $result: rgba($color, $level);
+  @return $result;
+}


### PR DESCRIPTION
Follow up from Teams conversation : https://teams.microsoft.com/l/message/19:fd15b51dacd24e70895ec1218a54ae06@thread.skype/1576023825331?tenantId=aee6e3c9-711e-4c7c-bd27-04f2307db20d&groupId=56fae21a-9407-4943-859f-a9bfcf0bbad3&parentMessageId=1576023825331&teamName=Calcite%20Design%20System&channelName=Calcite%20Components&createdTime=1576023825331

Adds transparency helper function to calcite-base, use case:

in calcite base: 
```
@function transparency($color, $level) {
 $result: rgba($color, $level);
 @return $result;
}  
```
 
in calcite-components / calcite-app-components _colors.scss: 
```
:root {
 ...
 --project-specific-transparent-var-1: #{transparency($ui-background, 0.2)};
 --project-specific-transparent-var-2: #{transparency($ui-background, 0.6)};
 --project-specific-transparent-var-3: #{transparency($ui-background, 0.96)};
 }

:host([theme="dark"]) {
 ...
 --project-specific-transparent-var-1: #{transparency($ui-background-dark, 0.2)};
 --project-specific-transparent-var-2: #{transparency($ui-background-dark, 0.6)};
 --project-specific-transparent-var-3: #{transparency($ui-background-dark, 0.96)};
}
```

in component file:
```
:host {
 background-color: var(--project-specific-transparent-var-3);
}
```
OR without using css vars (not as DRY as root-level css vars but may be useful for some folks):

```
:host {
 border: 1px solid transparency($h-yy-050, 0.9);
}
```
This is kind of a middle ground approach that isn't super prescriptive, and lets apps set their own needed transparency levels at the theme-level.