### PR TITLE
Sass Module Syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,19 @@ console.log(avenirLight); // '"Avenir Next", "Avenir", "Helvetica Neue", sans-se
 
 Note when using partial imports like this, the hyphenated variables become camel case.
 
+### Sass Module
+
+[Sass module](https://sass-lang.com/blog/the-module-system-is-launched) syntax is available on the [`sass-module` branch](https://github.com/Esri/calcite-base/tree/sass-module)
+
+```css
+@use "@esri/calcite-base/dist" as calcite;
+
+.myClass {
+  font-family: calcite.$avenir-family;
+  @include calcite.font-size(1);
+}
+```
+
 ## Licensing
 
 COPYRIGHT © 2020 Esri

--- a/dist/_animation.scss
+++ b/dist/_animation.scss
@@ -2,7 +2,7 @@
 /// Type mixins provide mixins for styling text.
 /// @group Animation
 ////
-@import "./_variables.scss";
+@use "./_variables.scss" as *;
 
 /// Generate a prefixed version of the animation property
 /// @param {string} $animations... - one or more (comma separated) animations to be prefixed
@@ -64,7 +64,7 @@
 ///   @include keyframes(out-up) {
 ///     0%   { transform: translate3d(0, 0, 0);}
 ///     100% { transform: translate3d(0, 100%, 0); }
-///   } 
+///   }
 @mixin keyframes ($name) {
   @-webkit-keyframes #{$name} {
     @content;

--- a/dist/_index.scss
+++ b/dist/_index.scss
@@ -1,7 +1,7 @@
-@import "./_variables.scss";
-@import "./_animation.scss";
-@import "./_responsive.scss";
-@import "./_spacing.scss";
-@import "./_shadow.scss";
-@import "./_type.scss";
-@import "./_utils.scss";
+@forward "./_animation.scss";
+@forward "./_responsive.scss";
+@forward "./_spacing.scss";
+@forward "./_shadow.scss";
+@forward "./_type.scss";
+@forward "./_utils.scss";
+@forward "./_variables.scss";

--- a/dist/_shadow.scss
+++ b/dist/_shadow.scss
@@ -3,7 +3,7 @@
 /// @group Shadow
 ////
 
-@import "./_variables.scss";
+@use "./_variables.scss" as *;
 
 /// Add a shadow to an element from one of calcite's two shadow levels
 /// @param {number} $level [1] - levels above the base (1|2)

--- a/dist/_spacing.scss
+++ b/dist/_spacing.scss
@@ -3,7 +3,7 @@
 /// @group Spacing
 ////
 
-@import "./_variables.scss";
+@use "./_variables.scss" as *;
 
 /// Apply n units of baseline as margin to the top of an elements
 /// @param {number} $n - positive or negative number (0 is normal)
@@ -44,8 +44,3 @@
 
 /// Apply a quarter unit of baseline as padding to the bottom of an element
 @mixin padding-trailer-quarter() { padding-bottom: 0.25 * $baseline; }
-
-
-
-
-

--- a/dist/_type.scss
+++ b/dist/_type.scss
@@ -3,7 +3,7 @@
 /// @group Type
 ////
 
-@import "./_variables.scss";
+@use "./_variables.scss" as *;
 
 /// Render text in a light weight (300)
 @mixin avenir-light() {


### PR DESCRIPTION
🎉 The Developers team is going to be using [Sass modules](https://sass-lang.com/blog/the-module-system-is-launched) in our new Gatsby theme; we need some syntax updates to `calcite-base` to support that. Since this will be a breaking change for consumers not using `dart-sass`, I'm open to ideas as to how to implement this as painlessly as possible. I think my current suggestion would be a standalone branch that rolls it's own releases. I'd be happy to maintain that going forward.

